### PR TITLE
Fix issue in which migrations might be run in the wrong order.

### DIFF
--- a/rivet-autoimporter/src/Main.hs
+++ b/rivet-autoimporter/src/Main.hs
@@ -1,6 +1,6 @@
 module Main where
 
-import           Data.List          (intercalate, isPrefixOf, isSuffixOf)
+import           Data.List          (intercalate, isPrefixOf, isSuffixOf, sort)
 import           Data.Monoid        ((<>))
 import           System.Directory   (getDirectoryContents)
 import           System.Environment (getArgs)
@@ -11,7 +11,7 @@ main =
   do (src:input:output:[]) <- getArgs
      ls <- lines <$> readFile input
      let (imports, rest) = splitImports ls
-     ms' <- getDirectoryContents "migrations"
+     ms' <- sort <$> getDirectoryContents "migrations"
      let ms = map dropExtension $
               filter (\m -> "M" `isPrefixOf` m && ".hs" `isSuffixOf` m) ms'
      let rivetImports = map (\m -> "import qualified " <> m) ms


### PR DESCRIPTION
GHC's `getDirectoryContents` is built on top of POSIX readdir(3),
which may or may not (depending on your OS) return entries in sorted
order. On my macOS 10.12 box, it does, whereas on my Ubuntu 16.04 box
they are returned in an (apparently) random order. Since
rivet-autoimporter expects the entries in the `migrations` directory
to be lexically sorted, this was failing on my Ubuntu install but
worked fine on OS X. The fix is to apply `sort` to the result.

For more information about why this is so, you can check out what 
Chris Siebenmann [wrote](https://utcc.utoronto.ca/~cks/space/blog/unix/ReaddirOrder) about readdir, or you can check out 
Gabe Gironda's [blog entry](https://www.gironda.org/2013/04/26/from-asset-precompilation-to-system-calls.html) in which he deals with a nearly identical bug.